### PR TITLE
fix 'address in use' error when creating second tunnel after hitting 'back'

### DIFF
--- a/lib/screens/robot.dart
+++ b/lib/screens/robot.dart
@@ -141,7 +141,7 @@ class _RobotState extends State<RobotScreen> with WindowListener {
     stdLog("Starting tunnel to machine...");
     stdLog(tunnelCmd!);
 
-    tunnelProc = await Process.start(viamCLI, args, runInShell: true);
+    tunnelProc = await Process.start(viamCLI, args, runInShell: false);
     setState(() {
       tunnelProc = tunnelProc;
     });


### PR DESCRIPTION
## Pre merge checklist
- [ ] test on windows + mac please; I tested a (linux -> windows) connection. it's possible that process management is different on win + mac
- [ ] any other acceptance testing
## What changed
- don't launch tunnel as shell
## Why
Bug. Repro steps are:
1. create a tunnel
2. close VNC app + in flutter app, hit 'back' in the top nav bar to return to the list of machines
3. click into a machine and create another tunnel (can be the same machine)
4. you'll get the 'address already in use' error in the screenshot

![Screenshot from 2025-03-09 14-37-06](https://github.com/user-attachments/assets/00ba4c9a-93c1-48a1-90d0-c164c9d71957)

This was happening because we were launching the subprocess with shell=true, which ends up creating a wrapper process for the shell. We were killing the wrapper but not the running tunnel.