### PR TITLE
Add Linux support

### DIFF
--- a/lib/helpers.dart
+++ b/lib/helpers.dart
@@ -97,6 +97,12 @@ Future<String?> getVNCPath() async {
     return join(dir.path, "rustdesk.exe");
   } else if (Platform.isMacOS) {
     return join(dir.path, "RustDesk.app");
+  } else if (Platform.isLinux) {
+    File rustdeskbinary = File("/usr/bin/rustdesk");
+    if (await rustdeskbinary.exists()) {
+      // assumes RustDesk has been installed via native Linux installer
+      return "/usr/bin/rustdesk";
+    }
   }
   return null;
 }


### PR DESCRIPTION
This patch adds viam_vnc support for Linux

It does not attempt to install the rustdesk binary.  That is best done by the user and their native linux package manager.